### PR TITLE
fix: troca url moved permanently e conserta regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const http = require('https');
-const req  = "https://www.nationalgeographic.com/photography/photo-of-the-day/";
+const req  = "https://www.nationalgeographic.com/photo-of-the-day/";
 
 http.get(req, (res) => {
 
@@ -13,7 +13,7 @@ http.get(req, (res) => {
 
   res.on('end', () => {
     try {
-      let result = content.match(/meta property="og:image" content="(.*)"/);
+      let result = content.match(/<meta ([^>]*)property="og:image" content="([^\"]*)"/);
       result = result[0].match(/content="(.*)"/);
       console.log(result[1]);
     } catch (e) {


### PR DESCRIPTION
- conserta a url `"https://www.nationalgeographic.com/photography/photo-of-the-day/"` foi [permanently moved](https://developer.mozilla.org/pt-BR/docs/Web/HTTP/Status/301) pra -> `"https://www.nationalgeographic.com/photo-of-the-day/"`
- faz um ajuste na regex pra pegar corretamente a url da imagem